### PR TITLE
Adds discovery of database proxy through reverse HTTP proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSION=$(shell python get_app_version.py)
+TEST_VERSION=v0.0.10
 
 all: version
 
@@ -30,3 +31,11 @@ docker_push:
 	@echo Pushing $(VERSION) and latest
 	docker push kostaleonard/populare:latest
 	docker push kostaleonard/populare:$(VERSION)
+
+docker_build_test:
+	@echo Building test
+	docker build -t kostaleonard/populare:test$(TEST_VERSION) .
+
+docker_push_test:
+	@echo Pushing test
+	docker push kostaleonard/populare:test$(TEST_VERSION)

--- a/lib/chat_repository.dart
+++ b/lib/chat_repository.dart
@@ -2,6 +2,7 @@
 //Interfaces with the database proxy to create, read, update, delete posts.
 
 import 'dart:convert';
+import 'dart:developer';
 import 'package:path/path.dart' as path;
 import 'package:http/http.dart' as http;
 import 'package:populare/chat_post.dart';
@@ -31,6 +32,7 @@ class ChatRepository {
   }
 
   Future<http.Response> getDbProxyHealth() {
+    print('Getting proxy health at $dbProxyHealthUri');
     return client.get(Uri.parse(dbProxyHealthUri));
   }
 
@@ -55,8 +57,10 @@ class ChatRepository {
     final beforeStr = 'before: "${before.toIso8601String()}"';
     final args = '(${[limitStr, beforeStr].join(', ')})';
     final body = '{ readPosts$args }';
+    print('Read posts query to $dbProxyGraphqlUri: $body');
     final response = await client.post(Uri.parse(dbProxyGraphqlUri),
         headers: ChatRepository.headers, body: body);
+    print('Read posts query response $response');
     if (response.statusCode != 200) {
       throw DbProxyCommunicationException('Could not reach database proxy');
     }

--- a/lib/chat_repository.dart
+++ b/lib/chat_repository.dart
@@ -2,7 +2,6 @@
 //Interfaces with the database proxy to create, read, update, delete posts.
 
 import 'dart:convert';
-import 'dart:developer';
 import 'package:path/path.dart' as path;
 import 'package:http/http.dart' as http;
 import 'package:populare/chat_post.dart';
@@ -32,7 +31,6 @@ class ChatRepository {
   }
 
   Future<http.Response> getDbProxyHealth() {
-    print('Getting proxy health at $dbProxyHealthUri');
     return client.get(Uri.parse(dbProxyHealthUri));
   }
 
@@ -57,10 +55,8 @@ class ChatRepository {
     final beforeStr = 'before: "${before.toIso8601String()}"';
     final args = '(${[limitStr, beforeStr].join(', ')})';
     final body = '{ readPosts$args }';
-    print('Read posts query to $dbProxyGraphqlUri: $body');
     final response = await client.post(Uri.parse(dbProxyGraphqlUri),
         headers: ChatRepository.headers, body: body);
-    print('Read posts query response $response');
     if (response.statusCode != 200) {
       throw DbProxyCommunicationException('Could not reach database proxy');
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,17 @@
 //Runs the app.
 
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:populare/chat.dart';
+import 'package:populare/chat_repository.dart';
 
 void main() {
-  runApp(PopulareApp());
+  print('Starting up populare app (stdout)');
+  print('dbProxyUri is http://192.168.64.3:30120/db-proxy');
+  print('base: ${Uri.base.authority}');
+  log('Starting up populare app');
+  //runApp(PopulareApp(chatWidget: ChatWidget(chatRepository: ChatRepository(dbProxyUri: 'http://192.168.64.3:30120/db-proxy'))));
+  runApp(PopulareApp(chatWidget: ChatWidget(chatRepository: ChatRepository(dbProxyUri: 'http://${Uri.base.authority}/db-proxy'))));
 }
 
 class PopulareApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,14 @@
 //Runs the app.
 
-import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:populare/chat.dart';
 import 'package:populare/chat_repository.dart';
 
 void main() {
-  print('Starting up populare app (stdout)');
-  print('dbProxyUri is http://192.168.64.3:30120/db-proxy');
-  print('base: ${Uri.base.authority}');
-  log('Starting up populare app');
-  //runApp(PopulareApp(chatWidget: ChatWidget(chatRepository: ChatRepository(dbProxyUri: 'http://192.168.64.3:30120/db-proxy'))));
-  runApp(PopulareApp(chatWidget: ChatWidget(chatRepository: ChatRepository(dbProxyUri: 'http://${Uri.base.authority}/db-proxy'))));
+  runApp(PopulareApp(
+      chatWidget: ChatWidget(
+          chatRepository: ChatRepository(
+              dbProxyUri: 'http://${Uri.base.authority}/db-proxy'))));
 }
 
 class PopulareApp extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.5
+version: 1.0.6
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
The [IAC repo](https://github.com/kostaleonard/populare-iac) now includes a reverse HTTP proxy in the Kubernetes yaml; clients will interface with the web app and database proxy through the reverse HTTP proxy, which means that we can use the base URI as the start of the database proxy URI.